### PR TITLE
Bump reserved size for legal-actions vector in quoridor.cc

### DIFF
--- a/open_spiel/games/quoridor/quoridor.cc
+++ b/open_spiel/games/quoridor/quoridor.cc
@@ -207,7 +207,7 @@ Move QuoridorState::ActionToMove(Action action_id) const {
 std::vector<Action> QuoridorState::LegalActions() const {
   std::vector<Action> moves;
   if (IsTerminal()) return moves;
-  int max_moves = 5;  // Max pawn moves, including jumps.
+  int max_moves = 6;  // Max pawn moves, including jumps.
   if (wall_count_[current_player_] > 0) {
     max_moves += 2 * (board_size_ - 1) * (board_size_ - 1);  // Max wall moves.
   }


### PR DESCRIPTION
The vector for legal moves is initialized with reserved space to hold the maxiumum number of possible legal moves. It sets max_moves to 5 initially as the max number of pawn moves, including jumps. However, that's only the max in a 2-player game. Normally, you can move in any of the 4 compass directions only. However, if there is an opponent pawn in one of those adjacent squares and a wall behind the pawn, you can choose to "mid-air jump" into one of the two squares diagonally-adjacent to the current pawn position on either side of the opponent. In a 2p game, there's only one possible opponent, so at most you can split one of the possible compass moves into two moves. However, with two or more opponents, it would be possible for two opposing adjacent squares to have opponents in them with walls behind and the other two squares to be open, leading to six possible moves.

This situation is unlikely to happen in a real game, and even if it does, all it means is that there will be one extra memory allocation to expand the vector, but it confused me, so I'm submitting a fix.